### PR TITLE
Add Slovak translation

### DIFF
--- a/_locales/sk/messages.json
+++ b/_locales/sk/messages.json
@@ -1,0 +1,334 @@
+{
+  "extensionName": {
+    "message": "HeadingsMap",
+    "description": "Názov rozšírenia."
+  },
+  "extensionDescription": {
+    "message": "Na zobrazenie, prehliadanie a kontrolu (z hľadiska prístupnosti a SEO) štruktúry nadpisov",
+    "description": "Popis rozšírenia."
+  },
+  "headersTab": {
+    "message": "Nadpisy",
+    "description": ""
+  },
+  "landmarksTab": {
+    "message": "Landmarks",
+    "description": ""
+  },
+  "outlineTab": {
+    "message": "HTML5 Outline",
+    "description": ""
+  },
+  "releaseNotesMenuLink": {
+    "message": "poznámky k vydaniu",
+    "description": ""
+  },
+  "privacyPolicyMenuLink": {
+    "message": "zásady ochrany súkromia",
+    "description": ""
+  },
+  "helpWithAccessibility": {
+    "message": "potrebujete pomoc s prístupnosťou?",
+    "description": ""
+  },
+  "helpWithAccessibilityOnLinkedIn": {
+    "message": "potrebujete pomoc s prístupnosťou?, otvorí sa v novom okne",
+    "description": ""
+  },
+  "settingsLabel": {
+    "message": "nastavenia",
+    "description": ""
+  },
+  "helpLabel": {
+    "message": "pomoc",
+    "description": ""
+  },
+  "refreshResultsMenuLink": {
+    "message": "obnoviť výsledky",
+    "description": ""
+  },
+  "closeButton": {
+    "message": "zavrieť",
+    "description": ""
+  },
+  "closeButtonAriaLabel": {
+    "message": "zavrieť panel",
+    "description": ""
+  },
+  "revealInViewButtonAriaLabel": {
+    "message": "zobraziť",
+    "description": ""
+  },
+  "copyButtonLabel": {
+    "message": "kopírovať výsledky",
+    "description": ""
+  },
+  "analysisAriaLabel": {
+    "message": "Analýza",
+    "description": ""
+  },
+  "maniMenuLabel": {
+    "message": "Menu",
+    "description": ""
+  },
+  "potentiallyHiddenPlural": {
+    "message": "potenciálne skryté",
+    "description": ""
+  },
+  "visible": {
+    "message": "viditeľné",
+    "description": ""
+  },
+  "collapseTreeNode": {
+    "message": "vnorené nadpisy",
+    "description": ""
+  },
+  "collapseLabel": {
+    "message": "zbaliť",
+    "description": ""
+  },
+  "collapserDescription": {
+    "message": "Tlačidlá na zbalenie/rozbalenie stromu nadpisov podľa úrovne nadpisu",
+    "description": ""
+  },
+  "expandLabel": {
+    "message": "rozbaliť",
+    "description": ""
+  },
+  "expandTreeNode": {
+    "message": "vnorené nadpisy",
+    "description": ""
+  },
+  "clickTheAnchor": {
+    "message": "Kliknutím na ikonu kotvy skopírujete URL adresu",
+    "description": ""
+  },
+  "headingLevel": {
+    "message": "Úroveň nadpisu",
+    "description": ""
+  },
+  "element": {
+    "message": "Prvok",
+    "description": ""
+  },
+  "emptyHeader": {
+    "message": "Prázdny nadpis",
+    "description": ""
+  },
+  "error": {
+    "message": "Chyba",
+    "description": ""
+  },
+  "potentiallyHidden": {
+    "message": "Potenciálne skryté",
+    "description": ""
+  },
+  "missingH1": {
+    "message": "Chýbajúci H1",
+    "description": ""
+  },
+  "wrongHierarchy": {
+    "message": "Nesprávna hierarchia úrovní",
+    "description": ""
+  },
+  "noHeadings": {
+    "message": "Žiadne nadpisy",
+    "description": ""
+  },
+  "topLevelLandmarkError": {
+    "message": "musí byť na najvyššej úrovni",
+    "description": ""
+  },
+  "repeatedUniqueLandmark": {
+    "message": "musí byť jedinečný",
+    "description": ""
+  },
+  "repeatedLandmark": {
+    "message": "je opakovaný",
+    "description": ""
+  },
+  "documents": {
+    "message": "Dokumenty",
+    "description": ""
+  },
+  "documentSelectorTitle": {
+    "message": "vyberte dokument, z ktorého sa má získať jeho štruktúra nadpisov/sekcií",
+    "description": ""
+  },
+  "anchor": {
+    "message": "Kotva",
+    "description": ""
+  },
+  "generatedBy": {
+    "message": "Vygenerované pomocou",
+    "description": ""
+  },
+  "heading": {
+    "message": "Nadpis",
+    "description": ""
+  },
+  "errorNoHeadingSection": {
+    "message": "Chyba: sekcia bez nadpisu",
+    "description": ""
+  },
+  "contributeMenuLink": {
+    "message": "prispieť",
+    "description": ""
+  },
+  "pinPanelLabel": {
+    "message": "otvárať automaticky vždy",
+    "description": ""
+  },
+  "pinPanelByDomainLabel": {
+    "message": "vždy otvoriť pre túto doménu",
+    "description": ""
+  },
+  "pinPanelByURLLabel": {
+    "message": "vždy otvoriť pre túto URL adresu",
+    "description": ""
+  },
+  "pinMenuLabel": {
+    "message": "otvoriť automaticky",
+    "description": ""
+  },
+  "switchToLeft": {
+    "message": "presunúť panel doľava",
+    "description": ""
+  },
+  "switchToRight": {
+    "message": "presunúť panel doprava",
+    "description": ""
+  },
+  "switchPositionLabel": {
+    "message": "zmeniť polohu panelu",
+    "description": ""
+  },
+  "active": {
+    "message": "aktívne",
+    "description": ""
+  },
+  "searchLabel": {
+    "message": "hľadať nadpis",
+    "description": ""
+  },
+  "searchButtonLabel": {
+    "message": "hľadať",
+    "description": ""
+  },
+  "closeSearchButtonLabel": {
+    "message": "zavrieť vyhľadávanie",
+    "description": ""
+  },
+  "clearText": {
+    "message": "vymazať hľadaný text",
+    "description": ""
+  },
+  "resultsListLabel": {
+    "message": "nadpisy",
+    "description": ""
+  },
+  "ariaLiveSwitchedToLeft": {
+    "message": "pripojené k ľavej strane zobrazenia",
+    "description": ""
+  },
+  "ariaLiveSwitchedToRight": {
+    "message": "pripojené k pravej strane zobrazenia",
+    "description": ""
+  },
+  "ariaLiveExpandedLevel": {
+    "message": "nadpisy v strome pod úrovňou {level} rozbalené",
+    "description": ""
+  },
+  "ariaLiveCollapsedLevel": {
+    "message": "nadpisy v strome pod úrovňou {level} zbalené",
+    "description": ""
+  },
+  "ariaLiveHeadingsCopied": {
+    "message": "štruktúra skopírovaná do schránky",
+    "description": ""
+  },
+  "shortcuts": {
+    "message": "klávesové skratky",
+    "description": ""
+  },
+  "shortcutEditLabel": {
+    "message": "stlačte ľubovoľnú klávesu (dá sa kombinovať s klávesmi modifikátormi 'control', 'shift', 'alt' alebo 'meta')",
+    "description": ""
+  },
+  "shortcutHintMessage": {
+    "message": "stlačte ľubovoľnú klávesu",
+    "description": ""
+  },
+  "shortcutErrorMessage": {
+    "message": "skratka sa už používa",
+    "description": ""
+  },
+  "shortcutEditButton": {
+    "message": "upraviť skratku",
+    "description": ""
+  },
+  "shortcutResetButton": {
+    "message": "obnoviť predvolenú skratku",
+    "description": ""
+  },
+  "shortcutSaveButton": {
+    "message": "uložiť skratku",
+    "description": ""
+  },
+  "shortcutCancelButton": {
+    "message": "zrušiť úpravu skratky",
+    "description": ""
+  },
+  "shortcutNotDefined": {
+    "message": "zatiaľ nedefinované",
+    "description": ""
+  },
+  "saved": {
+    "message": "uložené",
+    "description": ""
+  },
+  "openShortcutsDialog": {
+    "message": "Otvoriť dialógové okno so skratkami",
+    "description": ""
+  },
+  "openSettingsDialog": {
+    "message": "Otvoriť dialógové okno nastavení",
+    "description": ""
+  },
+  "updatePanelPosition": {
+    "message": "Zmeniť polohu panelu (vľavo - vpravo)",
+    "description": ""
+  },
+  "identifyHeadersInPage": {
+    "message": "Identifikovať nadpisy na stránke",
+    "description": ""
+  },
+  "searchInTree": {
+    "message": "Hľadať v strome",
+    "description": ""
+  },
+  "focusHeadingsTree": {
+    "message": "Presunúť fokus na naposledy vybratú položku v strome výsledkov",
+    "description": ""
+  },
+  "toggleTreeNodesByLevel": {
+    "message": "Zbaliť alebo rozbaliť uzly stromu podľa úrovne nadpisu",
+    "description": ""
+  },
+  "shortcutsPanelDescription": {
+    "message": "Toto je zoznam klávesových skratiek priradených k funkciám rozšírenia. Existujúce skratky môžete upraviť a prispôsobiť svojim potrebám. V jednej skratke je možné kombinovať viac klávesov. Povolené sú iba písmená, čísla, <kbd class='shortcut'>shift</kbd> a niektoré znaky: <kbd class='shortcut'>.</kbd>, <kbd class='shortcut'>,</kbd>, <kbd class='shortcut'>:</kbd>, <kbd class='shortcut'>;</kbd> ,<kbd class='shortcut'>/</kbd>, <kbd class='shortcut'><</kbd>, <kbd class='shortcut'>></kbd>, <kbd class='shortcut'>arrowLeft</kbd>, <kbd class='shortcut'>arrowRight</kbd>, <kbd class='shortcut'>arrowUp</kbd>, <kbd class='shortcut'>arrowDown</kbd>",
+    "description": ""
+  },
+  "shortcutsPanelDescriptionBottom": {
+    "message": "Ak máte návrhy týkajúce sa funkcie klávesových skratiek, napíšte prosím na <a href='mailto:headingsmap@gmail.com'>headingsmap@gmail.com</a>.",
+    "description": ""
+  },
+  "number": {
+    "message": "číslo",
+    "description": ""
+  },
+  "resizePanelAriaLabel": {
+    "message": "pomocou kurzorových klávesov zväčšite alebo zmenšite šírku panelu",
+    "description": ""
+  }
+}

--- a/html/configuration/sk.html
+++ b/html/configuration/sk.html
@@ -1,0 +1,345 @@
+<html lang="sk">
+<head><title>Možnosti</title></head>
+<body>
+
+<div class="content">
+    <h1 id="settings-header" class="headingsmap-exclude">Nastavenia</h1>
+
+    <div class="contents settings-content">
+        <fieldset class="fieldset">
+            <legend>Všeobecné</legend>
+            <div>
+                <label for="showHeadError">
+                    <input type="checkbox" name="showHeadError" id="showHeadError"/>
+                    Identifikovať chyby
+                </label>
+                <label for="highLightElements">
+                    <input type="checkbox" name="highLightElements" id="highLightElements"/>
+                    Zvýrazniť po kliknutí
+                </label>
+                <label for="showAnchors">
+                    <input type="checkbox" name="showAnchors" id="showAnchors" data-callback="refresh"/>
+                    Identifikovať kotvy
+                </label>
+                <label for="darkTheme">
+                    <input type="checkbox" name="darkTheme" id="darkTheme" data-callback="setTheme"/>
+                    Tmavý režim
+                </label>
+                <label for="savePanelWidthOnResize">
+                    <input type="checkbox" name="savePanelWidthOnResize" id="savePanelWidthOnResize"
+                           data-callback="updateInitialPanelWidth"/>
+                    Uložiť šírku pri zmene veľkosti
+                </label>
+                <label for="normalWrap">
+                    <input type="checkbox" name="normalWrap" id="normalWrap"/>
+                    Zalamovať dlhý text
+                </label>
+                <label for="showTooltip">
+                    <input type="checkbox" name="showTooltip" id="showTooltip" data-callback="setLinksBehavior"/>
+                    Zobraziť informačný popis (tooltip)
+                </label>
+                <label for="viewportIndicator">
+                    <input type="checkbox" name="viewportIndicator" id="viewportIndicator" data-callback="refresh"/>
+                    Prepojiť s viditeľnou oblasťou (viewport)
+                </label>
+                <label for="hideTreeResultsTools">
+                    <input type="checkbox" name="hideTreeResultsTools" id="hideTreeResultsTools"/>
+                    Skryť nástroje (vyhľadávanie a pod.)
+                </label>
+
+                <p class="note">
+                    <label for="language">
+                        Jazyk
+                        <select name="language" id="language">
+                        </select>
+                    </label>
+                    Zmena sa prejaví po reštartovaní rozšírenia (zatvorení a opätovnom otvorení).
+                </p>
+                <input type="hidden" name="initialPanelWidth" id="initialPanelWidth"/>
+            </div>
+            <div class="custom-scrollbar settings-information">
+                <h2>Podrobnosti</h2>
+                <ul>
+                    <li><strong>Identifikovať chyby</strong>: keď je aktívne, zvýrazní v strome položku, ktorá
+                        zodpovedá nadpisu obsahujúcemu chybu.
+                    </li>
+                    <li><strong>Zvýrazniť po kliknutí</strong>: po kliknutí na položku v strome sa na pár sekúnd
+                        zvýrazní obrysom príslušný nadpis v dokumente.
+                    </li>
+                    <li><strong>Identifikovať kotvy</strong>: ak sa nadpis dá použiť ako kotva, táto informácia sa
+                        zohľadní.
+                    </li>
+                    <li><strong>Tmavý režim</strong>: pri použití zmení štýl nástroja na tmavé pozadie
+                        a svetlú farbu popredia.
+                    </li>
+                    <li><strong>Uložiť šírku pri zmene veľkosti</strong>: ak je zaškrtnuté a panel sa zmení
+                        veľkosťou, nová
+                        šírka sa uloží, takže pri ďalšom použití nástroja zostane zachovaná.
+                    </li>
+                    <li><strong>Zalamovať dlhý text</strong>: predvolene sa text v položkách stromu skracuje. Po
+                        aktivácii tejto možnosti sa text v prípade potreby zalomí na viac riadkov.
+                    </li>
+                    <li><strong>Zobraziť informačný popis (tooltip)</strong>: keď je aktívne, pri presune kurzora nad
+                        strom sa zobrazí popis s informáciami.
+                    </li>
+                    <li><strong>Prepojiť s viditeľnou oblasťou (viewport)</strong>: keď je aktívne, zobrazí svetlé
+                        pozadie pri položkách, ktoré zodpovedajú nadpisom nachádzajúcim sa vo viditeľnej oblasti
+                        stránky.
+                    </li>
+                    <li><strong>Skryť nástroje</strong>: skryje tlačidlá a zjednoduší tak zobrazenie panela.</li>
+                    <li><strong>Jazyk</strong>: prepne jazyk. Nový jazyk sa použije až po opätovnom otvorení
+                        rozšírenia.
+                    </li>
+                </ul>
+            </div>
+        </fieldset>
+        <fieldset class="fieldset">
+            <legend>Štruktúra nadpisov</legend>
+            <div>
+                <label for="showHeadErrorH1">
+                    <input type="checkbox" name="showHeadErrorH1" id="showHeadErrorH1"/>
+                    Chyba, ak prvý nadpis nie je h1
+                </label>
+                <label for="showHeadLevels">
+                    <input type="checkbox" name="showHeadLevels" id="showHeadLevels"/>
+                    Zobraziť úroveň nadpisu
+                </label>
+                <label for="showEmptyHeadings">
+                    <input type="checkbox" name="showEmptyHeadings" id="showEmptyHeadings" data-callback="refresh"/>
+                    Zohľadniť prázdne nadpisy
+                </label>
+                <label for="showHiddenHeaders">
+                    <input type="checkbox" name="showHiddenHeaders" id="showHiddenHeaders" data-callback="refresh"/>
+                    Zohľadniť skryté nadpisy
+                </label>
+                <label for="showAriaLabelContent">
+                    <input type="checkbox" name="showAriaLabelContent" id="showAriaLabelContent"
+                           data-callback="refresh"/>
+                    Zohľadniť obsah "aria"
+                </label>
+            </div>
+            <div class="custom-scrollbar settings-information">
+                <h2>Podrobnosti</h2>
+                <ul>
+                    <li><strong>Chyba, ak prvý nadpis nie je h1</strong>: keď je aktívne, zvýrazní ako chybu
+                        situáciu, keď prvý nadpis nie je h1. Vyžaduje, aby bola aktívna aj možnosť "Identifikovať
+                        chyby".</li>
+                    <li><strong>Zobraziť úroveň nadpisu</strong>: v strome zobrazí úroveň nadpisu pred jeho textom.</li>
+                    <li><strong>Zohľadniť prázdne nadpisy</strong>: prázdne nadpisy sa začnú zohľadňovať v strome aj
+                        v jeho hierarchii.</li>
+                    <li><strong>Zohľadniť skryté nadpisy</strong>: identifikuje a zobrazí informácie o všetkých
+                        nadpisoch bez ohľadu na to, či sú skryté.</li>
+                    <li><strong>Zohľadniť obsah "aria"</strong>: ak nadpisy používajú atribúty <em>aria-label</em>
+                        alebo <em>aria-labelledby</em>, nástroj môže prevziať ich hodnotu a použiť ju ako textový
+                        obsah (dôvodom je, že čítačky obrazovky k nim môžu pristupovať a používať ich ako obsah).
+                    </li>
+                </ul>
+            </div>
+
+        </fieldset>
+        <fieldset class="fieldset">
+            <legend>Landmarks</legend>
+            <div>
+                <label for="isLandmarksTestActive">
+                    <input type="checkbox" name="isLandmarksTestActive" id="isLandmarksTestActive"
+                           data-callback="refresh disableFields"
+                           data-related-fields="showNonTopLevelLandmarksError showRepeatedLandmarksError showRepeatedUniqueLandmarksError"/>
+                    Analýza landmarks aktívna
+                </label>
+
+                <label></label>
+                <label for="showNonTopLevelLandmarksError">
+                    <input type="checkbox" name="showNonTopLevelLandmarksError" id="showNonTopLevelLandmarksError" data-callback="refresh"/>
+                    Chyba, ak <code>banner</code>, <code>complementary</code>, <code>contentinfo</code> alebo <code>main</code> nie sú na najvyššej úrovni
+                </label>
+                <label for="showRepeatedUniqueLandmarksError">
+                    <input type="checkbox" name="showRepeatedUniqueLandmarksError" id="showRepeatedUniqueLandmarksError" data-callback="refresh"/>
+                    Chyba, ak je viac ako jeden <code>banner</code>, <code>contentinfo</code> alebo <code>main</code>
+                </label>
+                <label for="showRepeatedLandmarksError">
+                    <input type="checkbox" name="showRepeatedLandmarksError" id="showRepeatedLandmarksError" data-callback="refresh"/>
+                    Chyba pri opakovaných landmarks bez popisu alebo s rovnakým popisom
+                </label>
+            </div>
+            <div class="custom-scrollbar settings-information">
+                <h2>Podrobnosti</h2>
+                <ul>
+                    <li><strong>Analýza landmarks aktívna</strong>: aktivuje alebo deaktivuje analýzu landmarks. Keď je analýza aktívna, ako karty sa zobrazia nadpisy aj landmarks.</li>
+                    <li><strong>Chyba, ak <code>banner</code>, <code>complementary</code>, <code>contentinfo</code> alebo <code>main</code> nie sú na najvyššej úrovni</strong>: tieto landmarks by mali byť na najvyššej úrovni.</li>
+                    <li><strong>Chyba, ak je viac ako jeden <code>banner</code>, <code>contentinfo</code> alebo <code>main</code></strong>: každá stránka môže obsahovať najviac jeden z každého typu.</li>
+                    <li><strong>Chyba pri opakovaných landmarks bez popisu alebo s rovnakým popisom</strong>: ak existuje viac landmarks s rovnakou úlohou (role), mali by obsahovať popis, ktorý ich odlíši.</li>
+                </ul>
+            </div>
+
+        </fieldset>
+        <fieldset class="fieldset">
+            <legend>
+                HTML 5 Outline
+            </legend>
+            <div>
+                <label for="isOutlineTestActive">
+                    <input type="checkbox" name="isOutlineTestActive" id="isOutlineTestActive"
+                           data-callback="refresh disableFields"
+                           data-related-fields="showOutLevels showOutElem showHiddenSections"/>
+                    Aktivovať analýzu
+                </label>
+                <p class="note">Neexistujú prehliadače ani asistenčné technológie s natívnou implementáciou W3C
+                    Outline algoritmu. Preto sa naň nedá spoliehať pri sprostredkovaní štruktúry dokumentu
+                    používateľom a autori by mali na tento účel používať úroveň nadpisov (<a
+                            href="https://www.w3.org/TR/2017/REC-html52-20171214/sections.html#creating-an-outline"
+                            target="_blank">HTML 5.2 Creating an outline</a>)
+                </p>
+
+                <label for="showOutLevels">
+                    <input type="checkbox" name="showOutLevels" id="showOutLevels"/>
+                    Zobraziť index sekcie
+                </label>
+                <label for="showOutElem">
+                    <input type="checkbox" name="showOutElem" id="showOutElem"/>
+                    Zobraziť značku sekcie
+                </label>
+                <label for="showHiddenSections">
+                    <input type="checkbox" name="showHiddenSections" id="showHiddenSections"
+                           data-callback="refresh updateActiveDocument"/>
+                    Zohľadniť skryté sekcie *
+                </label>
+            </div>
+            <p class="note">* Keď je aktívna možnosť "zohľadniť skryté sekcie", analýza môže mať výkonnostné
+                problémy pri dlhých dokumentoch</p>
+
+            <div class="custom-scrollbar settings-information">
+                <h2>Podrobnosti</h2>
+                <ul>
+                    <li><strong>Aktivovať analýzu</strong>: získavanie osnovy (outline) dokumentu môže mať vplyv na
+                        výkon, preto je jej vykonávanie voliteľné a predvolene deaktivované. Keď je aktívna, obe
+                        analýzy (nadpisy a HTML 5 Outline) sa zobrazia ako karty v paneli.
+                    </li>
+                    <li><strong>Zobraziť index sekcie</strong>: zobrazí index sekcie pred jej textom.</li>
+                    <li><strong>Zobraziť značku sekcie</strong>: do obsahu v strome zahrnie aj značku sekcie.
+                    </li>
+                    <li><strong>Zohľadniť skryté sekcie</strong>: identifikuje a zobrazí informácie o všetkých
+                        sekciách bez ohľadu na to, či sú skryté.
+                    </li>
+                </ul>
+            </div>
+        </fieldset>
+
+    </div>
+    <style>
+        #dialog-panel .content {
+            height: 100%;
+        }
+
+        #dialog-panel .settings-content {
+            overflow: hidden;
+            height: 100%;
+            display: flex;
+            flex-direction: column;
+        }
+
+        #dialog-panel .settings-content > div {
+            display: flex;
+            flex-direction: column;
+            height: 100%;
+        }
+
+        #dialog-panel .settings-information {
+            overflow: auto;
+        }
+
+        #dialog-panel .tab-button {
+            width: 33.3%;
+        }
+
+        #dialog-panel .tabs {
+            margin-top: 30px;
+        }
+
+        #dialog-panel .tab-button {
+            max-width: none;
+        }
+
+        #dialog-panel .tab-button:not([aria-selected=true]) {
+            margin-bottom: 1px;
+        }
+
+        #dialog-panel div[role=tabpanel].active {
+            display: flex;
+            flex-direction: column;
+            height: 100%;
+            padding: 10px;
+            box-sizing: border-box;
+        }
+
+        #dialog-panel .fieldset {
+            position: relative;
+            box-sizing: border-box;
+            border: none;
+            padding: 0 20px;
+            display: flex;
+            flex-direction: column;
+            height: 100%;
+        }
+
+        #dialog-panel .fieldset legend {
+            font-weight: bold;
+            position: absolute;
+            top: -5000px;
+            left: -5000px;
+        }
+
+        #dialog-panel .fieldset label {
+            display: block;
+            float: left;
+            width: 49%;
+            box-sizing: border-box;
+            margin: 10px 0;
+        }
+
+        #dialog-panel .fieldset label:nth-child(2n+1) {
+            margin-right: 2%;
+        }
+
+        #dialog-panel .fieldset p {
+            border-top: 1px dotted transparent;
+        }
+
+        #dialog-panel li {
+            font-size: .9rem;
+        }
+
+        #dialog-panel .fieldset p label {
+            float: none;
+            width: auto;
+            box-sizing: border-box;
+            margin: 10px 0 5px;
+            font-weight: bold;
+        }
+
+        #dialog-panel .fieldset legend label {
+            width: auto;
+            margin: auto;
+        }
+
+
+        #dialog-panel label:has([disabled]) {
+            opacity: .5;
+        }
+
+        #dialog-panel .fieldset select {
+            font-weight: normal;
+        }
+
+        #dialog-panel .fieldset label:nth-child(2n + 1) {
+            clear: left;
+        }
+
+        #dialog-panel code {
+            font-family: monospace;
+            font-size: .8em;
+            opacity: .8;
+        }
+    </style>
+</div>
+</body>
+</html>

--- a/html/contribute/sk.html
+++ b/html/contribute/sk.html
@@ -1,0 +1,49 @@
+<html lang="sk">
+<head><title>Ako prispieť</title></head>
+<body>
+<div class="content">
+    <h1 id="contribute-header" class="headingsmap-exclude">Ako prispieť</h1>
+    <div class="contents custom-scrollbar">
+        <p>
+            Ak sa vám toto rozšírenie páči a chcete prispieť, existuje viacero spôsobov:
+        </p>
+        <ul>
+            <li><strong>Preklady</strong>:
+                Rozšírenie je zatiaľ dostupné v piatich jazykoch (angličtina, francúzština, španielčina, poľština
+                a japončina) a bolo by skvelé pridať ďalšie jazyky.
+                Hovoríte po taliansky, po nemecky, ...?
+                Neváhajte a prispejte k internacionalizácii rozšírenia.
+                Vytvoril som repozitár na GitHub-e s textami určenými na preklad.
+                Adresa je <a href="https://github.com/rumoroso/headingsmap_translations/tree/main">https://github.com/rumoroso/headingsmap_translations/tree/main</a>.
+                Ak máte akúkoľvek pochybnosť alebo otázku, môžete napísať na e-mailovú adresu, ktorú som vytvoril pre toto rozšírenie: <a href="mailto:headingsmap@gmail.com?subject=Translation for headingsMap extension">headingsmap@gmail.com</a>.
+            </li>
+            <li><strong>Spätná väzba</strong>:
+                Ďalším spôsobom, ako prispieť, je zdieľanie spätnej väzby, nápadov na vylepšenia, hlásenie chýb
+                alebo neočakávaného správania a podobne.
+                Mnohé z vylepšení a opráv, ktoré rozšírenie dostalo, navrhli samotní používatelia.
+                Akýkoľvek komentár o rozšírení a o tom, čo robí alebo ako funguje, môžete poslať na e-mailovú
+                adresu <a href="mailto:headingsmap@gmail.com?subject=Feedback for headingsMap extension">headingsmap@gmail.com</a>.
+            </li>
+            <li><strong>Zdieľanie</strong>:
+                Ak sa vám rozšírenie páči, môžete ho tiež zdieľať (s kolegami, na sociálnych sieťach...)
+            </li>
+            <li><strong>Darovanie</strong>:
+                Ak ste otvorení tejto forme spolupráce, môžete podporiť aj samotný vývoj:
+                <form action="https://www.paypal.com/donate" method="post" target="_blank" lang="sk" style="display: block; text-align: center;">
+                    <input type="hidden" name="business" value="A8KA5SAF7BJDG"/>
+                    <input type="hidden" name="amount" value=""/>
+                    <input type="hidden" name="no_recurring" value="0"/>
+                    <input type="hidden" name="currency_code" value="EUR"/>
+                    <button type="submit" class="donate_button">darovať cez Paypal</button>
+                </form>
+                Ak nemôžete použiť tlačidlo na darovanie, no napriek tomu chcete prispieť, môžete tak urobiť
+                v Paypale pomocou adresy: headingsmap@gmail.com
+            </li>
+        </ul>
+        <p class="note">
+            Preklad do slovenčiny pripravil Radoslav Ďurač (GitHub: <a href="https://github.com/rraddatch" target="_blank">rraddatch</a>).
+        </p>
+    </div>
+</div>
+</body>
+</html>

--- a/html/help/sk.html
+++ b/html/help/sk.html
@@ -1,0 +1,107 @@
+<html lang="sk">
+<head><title>Pomoc a informácie</title></head>
+<body>
+<div class="content">
+    <h1 id="help-header">Pomoc</h1>
+    <div class="contents custom-scrollbar">
+        <p>HeadingsMap je rozšírenie prehliadača, ktoré zobrazuje štruktúru nadpisov webových stránok. Okrem toho
+            dokáže identifikovať potenciálne chyby (napríklad chýbajúce úrovne nadpisov), čo pomáha pri
+            kontrolách prístupnosti,
+            kontrole kvality,
+            SEO auditoch...</p>
+        <p>Rozšírenie tiež obsahuje voliteľnú funkciu na zobrazenie štruktúry landmarks.
+            Oba výsledky, nadpisy aj landmarks, sa zobrazujú v strome, ktorý
+            prepája úrovne vnorenia s hierarchiou dokumentu.</p>
+        <h2>Funkcie</h2>
+        <ul>
+            <li>Zobrazuje zoznam nadpisov s informáciou o ich úrovni a o tom, či narúšajú hierarchickú
+                štruktúru.
+            </li>
+            <li>Ak existujú prvky, ktoré používajú atribút <em>role</em> s hodnotou <em>heading</em>, sú tiež
+                zaradené do zoznamu. Ich úroveň vychádza z hodnoty atribútu <em>aria-level</em> (ak nie je
+                definovaný, predvolená hodnota je 2).
+            </li>
+            <li>Zoznam sekcií s informáciami o nadpisoch a upozorneniami na chyby v štruktúre</li>
+            <li>Získava informácie z hlavného dokumentu, ako aj z dokumentov vo vnútri iframe-ov
+            </li>
+            <li>Po kliknutí na nadpisy sa dokument posunie na pozíciu nadpisu/sekcie a zvýrazní
+                ju
+            </li>
+            <li>Deteguje zmeny v DOM-e a po ich dokončení aktualizuje stromy</li>
+            <li>Tmavý motív (voliteľné)</li>
+            <li>Voliteľne zobrazuje skryté nadpisy a sekcie (skryté pre asistenčné technológie). Keď sú
+                zobrazené, k položkám v strome sa pridá ikona, ktorá označuje, či ich rozšírenie rozpoznalo ako
+                viditeľné, alebo skryté
+            </li>
+            <li>Ak je nadpis (alebo sekcia) kotvou, odkaz vo výsledkoch má href smerujúci na ňu (užitočné pri
+                kopírovaní priamo zo stromu pomocou možnosti v kontextovej ponuke prehliadača)
+            </li>
+            <li>Ak obsah nadpisu/sekcie používa aria-label, jeho hodnota sa môže zobraziť (voliteľná vlastnosť
+                nastaviteľná v sekcii nastavení)
+            </li>
+            <li>Verzia pre viacero prehliadačov. Používa "browserExtensions API", takže je kompatibilné s Chrome,
+                Firefoxom, Microsoft Edge...
+            </li>
+        </ul>
+        <h2>Analýza HeadingsMap - nastavenia</h2>
+        <dl>
+            <dt>Chyba, ak prvý nadpis nie je h1</dt>
+            <dd>Bežne sa uznáva, že prvým nadpisom v dokumente by mal byť h1. Keď je táto možnosť aktívna,
+                spolu s "identifikovať chyby", porušenie tohto pravidla sa považuje za chybu
+            </dd>
+            <dt>Úroveň nadpisu</dt>
+            <dd>Zahŕňa úroveň nadpisu (1 až 6), ktorá sa použije ako značka (h1 až h6)</dd>
+            <dt>Zohľadniť skryté nadpisy</dt>
+            <dd>Keď dokument obsahuje nadpisy, ktoré sú skryté pre akýkoľvek nástroj (nielen vizuálne skryté,
+                ale aj skryté pre asistenčné technológie), v strome sa nezobrazujú. Po aktivácii
+                tejto možnosti sa zobrazia aj tieto
+            </dd>
+            <dt>Identifikovať kotvy</dt>
+            <dd>Keď nadpisy obsahujú kotvy, v strome sa zobrazí ikona. Kliknutím na ikonu sa URL adresa
+                skopíruje do schránky (rovnako ako pri akcii "kopírovať adresu odkazu" z prehliadača)
+            </dd>
+        </dl>
+        <h2>Analýza landmarks - nastavenia</h2>
+        <dl>
+            <dt>Analýza landmarks aktívna</dt>
+            <dd>Aktivuje alebo deaktivuje analýzu landmarks. Keď je analýza aktívna, ako karty sa zobrazia
+                nadpisy aj landmarks.</dd>
+
+            <dt>Chyba, ak <code>banner</code>, <code>complementary</code>, <code>contentinfo</code> alebo <code>main</code>
+                nie sú na najvyššej úrovni</dt>
+            <dd>Tieto landmarks by mali byť na najvyššej úrovni.</dd>
+
+            <dt>Chyba, ak je viac ako jeden <code>banner</code>, <code>contentinfo</code> alebo <code>main</code></dt>
+            <dd>Každá stránka môže obsahovať najviac jeden z každého typu.</dd>
+
+            <dt>Chyba pri opakovaných landmarks bez popisu alebo s rovnakým popisom</dt>
+            <dd>Ak existuje viac landmarks s rovnakou úlohou (role), mali by obsahovať popis, ktorý ich
+                odlíši.</dd>
+        </dl>
+
+        <h2>HTML 5 outline - nastavenia</h2>
+        <p>Podľa W3C neexistujú prehliadače ani asistenčné technológie, ktoré túto funkciu podporujú, takže
+            dobrý výsledok tohto testu má na výslednú prístupnosť len minimálny vplyv. Podľa W3C sa bude
+            sledovať akákoľvek implementácia a použitie týchto rôznych návrhov, čo môže v budúcnosti viesť
+            k významným zmenám v algoritme osnovy (outline).
+        </p>
+        <dl>
+            <dt>Zobraziť index sekcie</dt>
+            <dd>Podľa algoritmu by každá sekcia mala mať v strome svoj index. Toto nastavenie zobrazuje/skrýva
+                túto hodnotu
+            </dd>
+            <dt>Zobraziť značku sekcie</dt>
+            <dd>Pri tomto nastavení strom zobrazuje HTML značku, ktorá <a
+                    href="https://www.w3.org/TR/2011/WD-html5-author-20110809/headings-and-sections.html#outlines"
+                    target="_blank">vytvára sekcie</a>.
+            </dd>
+            <dt>Zohľadniť skryté sekcie</dt>
+            <dd>Keď dokument obsahuje skryté sekcie (nielen vizuálne skryté, ale aj skryté pre asistenčné
+                technológie), v strome sa nezobrazujú. Po aktivácii tejto možnosti sa zobrazia. Pri dlhých
+                dokumentoch to môže ovplyvniť výkon, keďže je potrebné skontrolovať všetky prvky v DOM-e
+            </dd>
+        </dl>
+    </div>
+</div>
+</body>
+</html>

--- a/html/privacyPolicy/sk.html
+++ b/html/privacyPolicy/sk.html
@@ -1,0 +1,71 @@
+<html lang="sk">
+<head><title>Zásady ochrany súkromia</title></head>
+<body>
+<div class="content">
+    <h1 id="privacy-policy-header" class="headingsmap-exclude">Zásady ochrany súkromia</h1>
+    <div class="contents custom-scrollbar">
+        <p>Tieto zásady ochrany súkromia sa vzťahujú na rozšírenie prehliadača <strong>HeadingsMap</strong> a ich
+            cieľom je informovať používateľov o oprávneniach, ktoré rozšírenie potrebuje na svoju činnosť,
+            a o dôvodoch, prečo sú tieto oprávnenia potrebné.</p>
+        <h2>Žiadny zber údajov</h2>
+        <p><strong>HeadingsMap</strong> nezbiera žiadne údaje z žiadnej webovej stránky. Vykonáva iba
+            analýzu HTML na strane prehliadača (na strane klienta) pomocou čistého (vanilla) javascriptu (bez
+            použitia knižníc alebo frameworkov tretích strán) a nezbiera, neukladá ani nezdieľa žiadne údaje
+            z webových dokumentov.</p>
+        <p>Bolo vyvinuté a je udržiavané s cieľom pomáhať a podporovať vývojárov, konzultantov, audítorov kvality
+            alebo akéhokoľvek iného koncového používateľa pri ich každodennom používaní/práci. Neobsahuje žiadne
+            skryté zámery.</p>
+        <h2>Oprávnenia prehliadača</h2>
+        <p><strong>HeadingsMap</strong> pristupuje k HTML stránky, ktorá je v danej chvíli
+            zobrazená v prehliadači, a to tak k obsahu priamo pochádzajúcemu zo značky html, ako aj k
+            dokumentom, ktoré sú zahrnuté prostredníctvom iframe-ov. Z tohto dôvodu, a tiež preto, že poskytuje
+            používateľovi sadu možností a preferencií, ktoré je možné uložiť (motív, poloha panela, typ analýzy,
+            identifikácia chýb atď.), vyžaduje niekoľko konkrétnych oprávnení od prehliadača, aby mohlo
+            fungovať.</p>
+
+        <p>Žiadne z oprávnení, ktoré rozšírenie vyžaduje, nezbiera údaje zo žiadnej webovej stránky. Sú potrebné
+            na vykonávanie analýzy HTML, poskytovanie informácií o HTML a štýloch aplikovaných na jeho prvky
+            a na poskytnutie sady možností, ktorými si používateľ môže určiť spôsob vykonávania analýzy a
+            zobrazovania výsledkov. Neexistuje žiadny zber údajov z obsahu ani žiadny zber údajov o stránkach,
+            na ktorých používateľ rozšírenie používa. Rozšírenie navyše nevykonáva žiadnu akciu, keď nie je
+            v prevádzke.</p>
+
+        <p>Toto je zoznam oprávnení prehliadača a dôvody, prečo sú potrebné:</p>
+        <dl>
+            <dt>all_urls</dt>
+            <dd>Toto oprávnenie umožňuje rozšíreniu fungovať na akejkoľvek URL adrese, pretože sa zhoduje s
+                akoukoľvek URL adresou, ktorá používa povolenú schému
+            </dd>
+            <dt>activeTab</dt>
+            <dd>Oprávnenie <code>activeTab</code> udeľuje dočasný prístup k stránke, na ktorej sa používateľ
+                nachádza, a umožňuje rozšíreniu použiť oprávnenie "tabs" na aktuálnej karte. Toto oprávnenie
+                nezobrazuje pri inštalácii žiadne upozornenie. Rozšírenie ho používa na:
+                <ul>
+                    <li>Volanie <code>tabs.executeScript</code> a <code>tabs.insertCSS</code> na aktuálnej karte.
+                        Spustenie skriptu je potrebné na analýzu DOM-u a vloženie CSS je potrebné na štylizáciu
+                        panela a na zvýrazňovanie prvkov (funkcia, ktorú rozšírenie má a ktorá spočíva v zvýraznení
+                        prvkov na stránke pri výbere ich informácií v paneli)
+                    </li>
+                    <li>Získanie URL adresy a názvu karty pomocou API, ktoré vracia objekt <code>tabs.Tab</code>.
+                        Jediným dôvodom získavania týchto informácií je zobraziť používateľovi HTML dokumenty,
+                        ktoré si prezerá, a umožniť mu rozhodnúť sa (výberom vo vlastnom selektore, ktorý zobrazuje
+                        ich názov), pre ktorý z nich sa má vykonať analýza.
+                    </li>
+                </ul>
+            </dd>
+            <dt>storage</dt>
+            <dd>Umožňuje rozšíreniam ukladať a načítavať údaje v prehliadači (nie na žiadnom vzdialenom mieste
+                ani serveri) a sledovať zmeny uložených položiek. Túto funkciu rozšírenie používa na uloženie a
+                načítanie používateľských preferencií, ako je usporiadanie panela, motív, upozornenia na chyby
+                atď.
+            </dd>
+            <dt>webNavigation</dt>
+            <dd>Pridáva poslucháčov udalostí pre rôzne fázy navigácie. Navigácia predstavuje prechod rámca
+                v prehliadači z jednej URL adresy na inú, zvyčajne (nie však vždy) v reakcii na akciu
+                používateľa, ako je kliknutie na odkaz alebo zadanie URL adresy do panela s adresou.
+            </dd>
+        </dl>
+    </div>
+</div>
+</body>
+</html>

--- a/html/releaseNotes/sk.html
+++ b/html/releaseNotes/sk.html
@@ -1,0 +1,493 @@
+<html lang="sk">
+<head><title>Poznámky k vydaniu</title></head>
+<body>
+<div class="content" id="release_notes">
+    <h1 id="release-notes-header" class="headingsmap-exclude">Poznámky k vydaniu</h1>
+    <div class="contents custom-scrollbar">
+        <dl>
+            <dt data-version="4.9.9">8/8/2026 (v 4.9.9)</dt>
+            <dd>Pridaný preklad do slovenčiny od Radoslava Ďuraču (GitHub: <a href="https://github.com/rraddatch" target="_blank">rraddatch</a>). Ďakujem veľmi pekne za túto dobrovoľnú spoluprácu, naozaj si to vážim.</dd>
+
+            <dt data-version="4.9.8">18/4/2025 (v4.9.8)</dt>
+            <dd>Opravená chyba, ktorá bránila zobrazeniu výsledkov po zatvorení a opätovnom otvorení panela.</dd>
+
+            <dt data-version="4.9.7">7/4/2025 (v4.9.7)</dt>
+            <dd>Opravená chyba, ktorá bránila úplnému načítaniu rozšírenia.</dd>
+
+            <dt data-version="4.9.6">6/4/2025 (v4.9.6)</dt>
+            <dd>Obnovená analýza HTML5 Outline.</dd>
+            <dd>Opravená chyba chýbajúcich textov v popise (tooltip) s informáciami o sekciách v iframe-och.
+            </dd>
+            <dd>Prvok HGROUP bol odstránený, pretože bol napokon vyradený zo špecifikácie a žiadny nástroj ho
+                nikdy neimplementoval podľa pôvodne zamýšľanej HTML špecifikácie.
+            </dd>
+
+            <dt data-version="4.9.4" data-new-features="#landmarksTab-tab,#settingsTab-2-tab,#settings">23/3/2025 (v
+                4.9.4)
+            </dt>
+            <dd>Pridaná analýza štruktúry landmarks.</dd>
+            <dd>Odstránená analýza HTML5 Outline.</dd>
+            <dd>Vylepšenia prístupnosti.</dd>
+
+            <dt data-version="4.8.7">27/8/2024 (v 4.8.7)</dt>
+            <dd>Oprava chyby v službe klávesových skratiek.</dd>
+
+            <dt data-version="4.8.6">26/8/2024 (v 4.8.6)</dt>
+            <dd>Vylepšenia v klávesovej interakcii s vyhľadávaním.</dd>
+
+            <dt data-version="4.8.5">17/8/2024 (v 4.8.5)</dt>
+            <dd>Aktualizované vyhľadávacie rozhranie a spôsob interakcie s ním. Okrem iných zmien zoznam
+                výsledkov teraz obsahuje úrovne nadpisov (keď je v nastaveniach aktívne "zobraziť úroveň
+                nadpisu").</dd>
+            <dd>Opravená chyba, kvôli ktorej strom obsahoval HTML značky. Keď vykreslený text nadpisu obsahoval
+                značku, bola spracovaná ako HTML a zahrnutá do stromu ako taká, čím sa narúšal ako layout, tak
+                aj ostatné prvky v strome.</dd>
+
+            <dt data-version="4.8.4">5/3/2024 (v 4.8.4)</dt>
+            <dd>Aktualizovaný spôsob pridávania štýlov.</dd>
+
+            <dt data-version="4.8.3">27/2/2024 (v 4.8.3)</dt>
+            <dd>Opravená chyba v štýloch, kvôli ktorej niektoré vstupné polia pri písaní do nich zmizli
+                (zvyčajne smerom doľava). Chyba bola zistená iba v prehliadači Chrome a na konkrétnych
+                stránkach (napríklad pri zadávaní názvu udalosti v Google Calendar).</dd>
+
+            <dt data-version="4.8.2">22/2/2024 (v 4.8.2)</dt>
+            <dd>Zmenu veľkosti panela je možné vykonať pomocou klávesnice. Prvok na zmenu veľkosti je teraz
+                možné zaostriť (focus). Keď má fokus, klávesmi so šípkami sa mení šírka panela.</dd>
+
+            <dt data-version="4.8.1">18/2/2024 (v 4.8.1)</dt>
+            <dd>Vylepšený spôsob zobrazovania panela, takže pevne umiestnené prvky na stránke sa teraz
+                identifikujú a nezostávajú za ním skryté.</dd>
+
+            <dt data-version="4.7.11">7/2/2024 (v 4.7.11)</dt>
+            <dd>Opravená minimálna veľkosť písma, takže ak stránka nastaví koreňovú veľkosť písma menšiu, ako
+                je predvolená hodnota prehliadača, rozšírenie si aj tak zachová predvolenú hodnotu prehliadača
+                ako minimum.</dd>
+            <dd>Opravený štýl selektora dokumentov (zobrazovaného, keď sú na stránke rámce) na karte HTML 5
+                Outline.</dd>
+            <dd>Drobné opravy.</dd>
+
+            <dt data-version="4.7.10">29/1/2024 (v 4.7.10)</dt>
+            <dd>Pridaný preklad do japončiny od používateľa 'k-ta-yamada'. Veľmi pekne ďakujem za túto
+                spoluprácu a vynaložené úsilie. Naozaj si to vážim.</dd>
+
+            <dt data-version="4.7.9">22/1/2024 (v 4.7.9)</dt>
+            <dd>Aktualizované na identifikáciu toho, či sa nadpisy nachádzajú vo vnútri prvku
+                <code>details</code> a či je tento prvok otvorený, alebo nie.</dd>
+
+            <dt data-version="4.7.8">20/1/2024 (v 4.7.8)</dt>
+            <dd>Keď sú na stránke skryté iframe-y, identifikujú sa v selektore dokumentov na karte
+                HTMLOutline.</dd>
+            <dd>Drobné opravy súvisiace s ikonou pri skrytých prvkoch.</dd>
+
+            <dt data-version="4.7.6">17/1/2024 (v 4.7.6)</dt>
+            <dd>Vylepšený spôsob načítavania popiskov.</dd>
+            <dd>Znížený počet požiadaviek na súbory rozšírenia.</dd>
+            <dd>Zachovanie vybraného dokumentu v rozbaľovacom zozname pri prepínaní medzi analýzami.</dd>
+            <dd>Vylepšený odhad rozmerov dialógového okna.</dd>
+            <dd>Drobné opravy.</dd>
+
+            <dt data-version="4.7.5">11/1/2024 (v 4.7.5)</dt>
+            <dd>Vylepšený výkon.</dd>
+            <dd>Opravy chýb.</dd>
+
+            <dt data-version="4.7.3">3/1/2024 (v 4.7.3)</dt>
+            <dd>Vylepšená klávesová interakcia v strome výsledkov. Ďakujeme Andrewovi Kirkpatrickovi za jeho
+                spätnú väzbu a návrhy.
+            </dd>
+
+            <dt data-version="4.7.1">28/12/2023 (v 4.7.1)</dt>
+            <dd>Nové <strong>klávesové skratky pre interakciu s rozšírením</strong>. Teraz obsahuje niekoľko
+                skratiek na spustenie akcií, ako je funkcia vyhľadávania, zbalenie uzlov vo výsledkoch,
+                otvorenie dialógového okna nastavení a dokonca aj otvorenie dialógového okna so skratkami.
+                Keďže používanie skratiek by mohlo kolidovať s niektorými skratkami asistenčných technológií,
+                spravil som ich konfigurovateľnými. Niektoré majú predvolenú hodnotu a iné zatiaľ nie sú
+                definované, takže si ich používatelia môžu nastaviť podľa svojich potrieb.
+            </dd>
+            <dd>Tlačidlá na zmenu polohy panela a prístup k nastaveniam sú teraz súčasťou hlavnej ponuky.
+                Hlavným cieľom bolo zjednodušiť zobrazenie a tiež znížiť počet stlačení klávesov pri interakcii
+                s klávesnicou.
+            </dd>
+            <dd>Možnosť <strong>skryť nástroje</strong>, ktoré ponúka karta nadpisov (tlačidlá na zbaľovanie
+                podľa úrovní, vyhľadávanie a tlačidlá kopírovania). Hlavným cieľom, ako už bolo spomenuté, bolo
+                zjednodušiť zobrazenie. Hoci je tlačidlo vyhľadávania skryté, klávesová skratka na vyhľadávanie
+                stále funguje a zobrazí ho. Je len vizuálne skryté a dostupné iba pomocou klávesnice.
+            </dd>
+            <dd>Vylepšenia prístupnosti.</dd>
+            <dd>Vylepšenia v správaní dialógového okna, ponúk atď.</dd>
+
+            <dt data-version="4.6.3">13/12/2023 (v 4.6.3)</dt>
+            <dd>Vylepšená prístupnosť.</dd>
+            <dd>Vylepšené štýly.</dd>
+
+            <dt data-version="4.6.2">11/12/2023 (v 4.6.2)</dt>
+            <dd>Nová funkcia vyhľadávania na hľadanie nadpisov v strome.</dd>
+            <dd>Vylepšenia tlačidiel na zbalenie/rozbalenie stromu podľa úrovní (vylepšená prístupnosť,
+                správanie, klávesová interakcia atď.).
+            </dd>
+            <dd>Stromy teraz používajú správnu ARIA rolu a očakávané správanie pri ovládaní klávesnicou.</dd>
+            <dd>Vylepšené veľkosti tlačidiel.</dd>
+
+            <dt data-version="4.5.8">17/11/2023 (v 4.5.8)</dt>
+            <dd>Opravená chyba, ktorá bránila zobrazeniu výsledkov, keď existovali obrázky bez atribútu src.</dd>
+
+            <dt data-version="4.5.7">11/10/2023 (v 4.5.7)</dt>
+            <dd>Aktualizovaný štýl lišty na zmenu veľkosti, takže kurzor teraz zobrazuje celú lištu ako
+                interaktívny prvok.</dd>
+            <dd>Opravená chyba s tlačidlami na "zbaľovanie" zobrazovanými pri chýbajúcich medziľahlých
+                úrovniach nadpisov.</dd>
+
+            <dt data-version="4.5.6">12/8/2023 (v 4.5.6)</dt>
+            <dd>Pridaná podpora pre Shadow DOM. Ak sa vo vnútri Shadow DOM nachádzajú nadpisy alebo obsah,
+            identifikujú sa rovnako ako akýkoľvek iný nadpis v DOM-e.</dd>
+            <dd>Vylepšený spôsob zobrazovania nadpisov na stránke.</dd>
+            <dd>Opravy chýb.</dd>
+
+            <dt data-version="4.5.5">12/8/2023 (v 4.5.5)</dt>
+            <dd>Opravy chýb.</dd>
+
+            <dt data-version="4.5.3">10/8/2023 (v 4.5.3)</dt>
+            <dd>Vylepšenia štýlov.</dd>
+
+            <dt data-version="4.5.1">8/8/2023 (v 4.5.1)</dt>
+            <dd>Vylepšený spôsob zobrazovania nadpisov na stránke.</dd>
+
+            <dt data-version="4.5.0">4/8/2023 (v 4.5.0)</dt>
+            <dd>Nová možnosť zobraziť nadpisy na stránke. Aktivuje sa tlačidlom umiestneným vedľa stromu. Pri
+                presune myši nad nadpis sa tento identifikuje v strome.</dd>
+            <dd>Nový spôsob zbaľovania/rozbaľovania položiek v strome pomocou tlačidiel umiestnených v jeho
+                pravom hornom rohu.</dd>
+            <dd>Aktualizované na zobrazenie štruktúry nadpisov vrátane iframe-ov v tom istom strome. Selektor
+                dokumentov bol presunutý na kartu HTML5Outline, pretože špecifikácia nedefinuje, ako sa
+                generuje osnova (outline), keď sa vyskytujú iframe-y, takže sa odhaduje pre každý dokument
+                samostatne.</dd>
+
+            <dt data-version="4.4.4">20/7/2023 (v 4.4.4)</dt>
+            <dd>Pridaný preklad do poľštiny od Rafała Jendrzejewského. Veľmi pekne ďakujem za dobrovoľnú
+                spoluprácu. Naozaj si to vážim.</dd>
+
+            <dt data-version="4.4.3">29/5/2023 (v 4.4.3)</dt>
+            <dd>Opravená chyba, kvôli ktorej mal zoznam dokumentov (keď existujú iframe-y) chyby v
+                možnostiach.</dd>
+
+            <dt data-version="4.4.2">22/5/2023 (v 4.4.2)</dt>
+            <dd>Opravená chyba, ktorá spôsobovala zlyhanie rozšírenia, keď bol doctype dokumentu XHTML 1.1.
+                Ďakujeme Josému Luisovi Gonzálezovi za nahlásenie a pomoc pri oprave.</dd>
+            <dd>Drobné opravy vo francúzskom preklade (opäť ďakujeme Luce Carevic za ich nájdenie a ochotu
+                ich aktualizovať).</dd>
+
+            <dt data-version="4.4.1">19/5/2023 (v 4.4.1)</dt>
+            <dd>Opravená chyba súvisiaca s prekladom, kvôli ktorej sa niektoré texty vždy zobrazovali v
+                angličtine.</dd>
+            <dd>Pridaný chýbajúci popisok vo francúzštine.</dd>
+
+            <dt data-version="4.4.0">19/5/2023 (v 4.4.0)</dt>
+            <dd>Pridaný preklad do francúzštiny od Luce Carevic. Veľmi pekne ďakujem za jej ochotu spolupracovať
+                týmto spôsobom a za to, že to urobila tak rýchlo.</dd>
+            <dd>Opravená chyba, ktorá bránila inicializácii nastavenia pre popis (tooltip) s informáciami o
+                nadpise, kým sa rozšírenie znova neotvorilo.</dd>
+
+            <dt data-version="4.3.1">7/5/2023 (v 4.3.1)</dt>
+            <dd>Zabránenie fokusu na skryté prvky. Keď boli dialógové okná (nastavenia, pomoc, poznámky k
+                vydaniu atď.) zatvorené, stále bolo možné ich zaostriť, takže pri prístupe pomocou klávesnice
+                fokus prechádzal cez všetky ich položky. Táto zmena tomu zabraňuje.</dd>
+            <dd>Pridané klávesy so šípkami arrowRight a arrowLeft na rozbalenie/zbalenie uzlov stromu (keď majú
+                fokus).</dd>
+            <dd>Keď má položka fokus, kláves "enter" presunie fokus na nadpis, ktorý jej zodpovedá.</dd>
+
+            <dt data-version="4.3.0">6/5/2023 (v 4.3.0)</dt>
+            <dd>Pridané tlačidlo na kopírovanie stromu do schránky.</dd>
+            <dd>Pridaná možnosť "vždy otvoriť" pre aktuálnu URL adresu.</dd>
+            <dd>Vylepšený kód, ktorý generuje ponuky, takže teraz sú to skutočné tlačidlá.</dd>
+            <dd>Zahŕňa aj niektoré vylepšenia prístupnosti.</dd>
+
+            <dt data-version="4.2.3">23/3/2023 (v 4.2.3)</dt>
+            <dd>Aktualizovaný spôsob, akým je možné ho udržať otvorený.</dd>
+
+            <dt data-version="4.2.2">29/3/2023 (v 4.2.2)</dt>
+            <dd>Vylepšený spôsob, akým panel zaberá priestor z tela stránky pri otváraní a zmene veľkosti.</dd>
+
+            <dt data-version="4.2.1">21/3/2023 (v 4.2.1)</dt>
+            <dd>Teraz je medzi panelom a telom stránky trochu priestoru.</dd>
+            <dd>V kóde nastali niektoré zmeny, ktoré síce nie sú zamerané na používateľa, no boli potrebné na
+                zlepšenie kvality kódu, aby sa lepšie udržiaval a aby sa doň dali jednoduchšie zahrnúť budúce
+                zmeny.</dd>
+
+            <dt data-version="4.2.0">14/3/2023 (v 4.2.0)</dt>
+            <dd>Pridané klávesové skratky na prepínanie uzlov v strome podľa úrovne nadpisu. Vo Windows použite
+                kombináciu klávesu "alt" s ľubovoľným číselným klávesom na zbalenie (alebo rozbalenie) uzlov
+                stromu, ktoré zodpovedajú nadpisom rovnakej úrovne, ako je dané číslo. Napríklad "alt + 2"
+                zbalí (alebo rozbalí) všetky uzly vytvorené z prvkov h2. Na Macu je kombináciou "ctrl + cmd"
+                s úrovňou nadpisu. Toto správanie je dostupné iba pre strom "headingsMap", nie však pre strom
+                "HTML5 outline".</dd>
+            <dd>Opravený problém s nesprávnymi štýlmi panela, keď sa nachádza na novej karte, ktorá nie je
+                priamo zaostrená (napríklad keď sa odkaz otvorí na novej karte).</dd>
+
+            <dt data-version="4.1.0">13/3/2023 (v 4.1.0)</dt>
+            <dd>Pri otváraní panela sa zachová okraj (margin) prvku BODY. Vďaka tomu je medzi panelom a
+                obsahom tela stránky určitý odstup.</dd>
+
+            <dt data-version="4.0.0">7/3/2023 (v 4.0.0)</dt>
+            <dd>Nová možnosť automatického otvárania rozšírenia. Dá sa nastaviť tak, aby sa otváralo vždy,
+                alebo iba na doméne aktuálne aktívnej stránky. Používa sa prostredníctvom ponuky (s ikonou
+                "špendlíka") umiestnenej na hornej lište, ktorá obsahuje obe možnosti, otvárané pomocou
+                tlačidla s ikonou "špendlíka".</dd>
+            <dd>Možnosť zmeny polohy panela má teraz vlastné tlačidlo na hornej lište.</dd>
+            <dd>Ponuka nastavení je teraz tiež dostupná priamo z hornej lišty.</dd>
+            <dd>Nová možnosť zohľadňovať alebo ignorovať nadpisy bez obsahu. Predvolene sa ignorujú (v
+                predchádzajúcich verziách sa zohľadňovali vždy).</dd>
+            <dd>Spôsob zobrazenia dialógových okien (pre nastavenia, pomoc atď.) sa mierne zmenil.</dd>
+            <dd>Táto verzia tiež obsahuje ďalšie zmeny na zlepšenie spôsobu, akým sa funkcionalita vkladá a
+                spúšťa. Boli vykonané testy na overenie, že všetko funguje podľa očakávania, no
+                pravdepodobne som prehliadol niektoré scenáre, ktoré sa môžu vyskytnúť. Ak sa v správaní alebo
+                vo výsledkoch objaví niečo neočakávané, kontaktujte ma prosím na e-mail
+                <a href="mailto:headingsmap@gmail.com">headingsmap@gmail.com</a>.</dd>
+
+            <dt data-version="3.10.1">26/7/2021 (v 3.10.1)</dt>
+            <dd>Keď prvok nadpisu (prvky h1 až h6) používa atribút <em>aria-level</em>, rozšírenie ho použije
+                na určenie jeho úrovne.</dd>
+            <dd>Vylepšené štýly dialógových okien.</dd>
+            <dd>Pridaný španielsky preklad.</dd>
+            <dd>Nová sekcia o možnostiach prispievania.</dd>
+            <dd>Odstránená možnosť ponuky "obnoviť výsledky".</dd>
+
+            <dt data-version="3.10.0">28/2/2021 (v 3.10.0)</dt>
+            <dd>Pridaná voliteľná vizuálna pomôcka, ktorá pomáha identifikovať nadpisy/sekcie momentálne
+                nachádzajúce sa vo viditeľnej oblasti (viewport). Pri posúvaní stránky, ak sa nadpis (alebo
+                sekcia pre strom HTML Outline) nachádza vo viditeľnej oblasti, príslušná položka v strome sa
+                zvýrazní zmenou pozadia a 4px čiarou na pravej strane. Túto možnosť je možné aktivovať v
+                paneli nastavení (začiarkavacie políčko s popiskom "Prepojiť s viditeľnou oblasťou")
+            </dd>
+            <dd>Opravená chyba v strome headingsMap, keď bola aktívna možnosť zohľadniť skryté nadpisy</dd>
+            <dd>Vylepšená prístupnosť komponentu</dd>
+
+            <dt data-version="3.9.1">7/12/2020 (v 3.9.1)</dt>
+            <dd>Opravená chyba, kvôli ktorej sa ignoroval obsah prvkov s rolou "presentation"</dd>
+            <dd>Zverejnený <a href="https://rumoroso.bitbucket.io/headingsmap/todo.html">zoznam potenciálnych
+                vylepšení a nových funkcií</a>. Zoznam vychádza aj z požiadaviek trhu a spätnej väzby
+                používateľov
+            </dd>
+
+            <dt data-version="3.9.0">10/10/2020 (v 3.9.0)</dt>
+            <dd>Skrytie karty, keď analýza HTML5 Outline nie je aktívna (na aktiváciu zaškrtnite "nastavenia >
+                strom HTML 5 Outline")
+            </dd>
+            <dd>Pridaný štýl výpustky (ellipsis) pre hlavný nadpis (keď je aktívna možnosť "zalamovať dlhý
+                text", zalamuje sa aj tento text)
+            </dd>
+            <dd>Pridaný obsah zásad ochrany súkromia a odkaz v ponuke</dd>
+
+            <dt data-version="3.8.3">29/6/2020 (v 3.8.3)</dt>
+            <dd>Aktualizované písmo (font-family) použité v popise (tooltip)</dd>
+
+            <dt data-version="3.8.2">28/6/2020 (v 3.8.2)</dt>
+            <dd>Pridaný voliteľný popis (tooltip), ktorý zobrazuje informácie o nadpise alebo sekcii (zobrazí
+                sa pri presune myši nad strom). Dá sa aktivovať v dialógovom okne možností a predvolene je
+                deaktivovaný
+            </dd>
+            <dd>Prvky select v dialógovom okne možností nahradené začiarkavacími políčkami. Vďaka tomu
+                používateľ potrebuje na zmenu hodnoty možnosti iba jedno kliknutie
+            </dd>
+            <dd>Pridaná klávesová interakcia so stromom, takže keď má položka fokus:
+                <ul>
+                    <li>šípka nahor/šípka nadol: presunie fokus na nasledujúcu alebo predchádzajúcu položku</li>
+                    <li>kláves enter: zbalí/rozbalí vnorenú skupinu položky</li>
+                    <li>kláves escape: ak je zobrazený popis (tooltip), zatvorí ho</li>
+                </ul>
+            </dd>
+
+            <dt data-version="3.8.1">21/6/2020 (v 3.8.1)</dt>
+            <dd>Pridaná možnosť identifikovať, ktoré prvky nástroj považuje za skryté. Keď je aktívna možnosť
+                zohľadniť skryté prvky (pre karty nadpisov a/alebo HTML5 Outline), na pravej strane položiek
+                zodpovedajúcich skrytým prvkom sa zobrazí ikona a celkový počet sa zobrazí ako legenda v spodnej
+                časti. Majte na pamäti, že spôsob, akým rozšírenie identifikuje skryté prvky, vychádza z
+                odhadov na základe ich štýlov, no dokumenty môžu implementovať alternatívne spôsoby skrývania
+                obsahu (ďakujeme Alirezovi Esmikhanimu za návrhy nových funkcií a za nahlásenie chýb, ako pre
+                túto verziu, tak aj pre predchádzajúcu)
+            </dd>
+            <dd>Aktualizované na použitie shadow DOM</dd>
+            <dd>Aktualizovaný zoznam požadovaných funkcií na analýzu:
+                <ul>
+                    <li>Identifikovať počiatočnú úroveň nadpisu pre sekčné prvky v paneli HTML5 Outline</li>
+                    <li>Vylepšiť dialógové okno možností</li>
+                    <li>Identifikovať v paneli relatívnu pozíciu posunu na stránke</li>
+                    <li>Ponúknuť alternatívny spôsob pre používateľov, ktorí chcú zdieľať nápady na nové
+                        funkcie, poskytnúť spätnú väzbu alebo nahlásiť chyby
+                    </li>
+                    <li>Zobraziť zoznam budúcich funkcií a ich stav</li>
+                    <li>Verzia pre Microsoft Edge</li>
+                    <li>...</li>
+                </ul>
+            </dd>
+
+            <dt data-version="3.8.0">14/6/2020 (v 3.8.0)</dt>
+            <dd>Pridaná možnosť zohľadniť prvky HGROUP v osnove HTML5</dd>
+            <dd>Vylepšené posúvanie k zvýraznenému prvku</dd>
+            <dd>Vylepšený výkon pri generovaní osnovy HTML5</dd>
+            <dd>Opravy chýb súvisiace s:
+                <ul>
+                    <li>Osnova HTML5 (nesprávne nezohľadňovala prázdne prvky section)</li>
+                    <li>Atribút aria-labelledby</li>
+                    <li>Chyby pri identifikácii neštandardných HTML prvkov</li>
+                    <li>Layout</li>
+                    <li>iné</li>
+                </ul>
+            </dd>
+
+            <dt data-version="3.7.0">27/5/2020 (v 3.7.0)</dt>
+            <dd>Pridaná možnosť zalamovať dlhý text na viac riadkov namiesto použitia výpustky (ďakujeme
+                Yang Yang za návrh a spätnú väzbu)
+            </dd>
+
+            <dt data-version="3.6.7">24/5/2020 (v 3.6.7)</dt>
+            <dd>Zo stromu nadpisov vylúčené prvky nadpisov, ktoré majú platný atribút role s hodnotou inou ako
+                "heading" (ďakujeme Audrey Maniez za jej návrh a spätnú väzbu)
+            </dd>
+
+            <dt data-version="3.6.6">6/4/2020 (v 3.6.6)</dt>
+            <dd>Pridaná možnosť "identifikovať kotvy". Keď je aktívna (predvolená hodnota), ak nadpisy alebo
+                sekcie obsahujú kotvy, položky v strome zobrazia ikonu. Kliknutím na ňu sa kotva skopíruje do
+                schránky. Kotvu je tiež možné skopírovať pomocou akcie prehliadača "kopírovať adresu odkazu"
+            </dd>
+
+            <dt data-version="3.6.5">2/3/2020 (v 3.6.5)</dt>
+            <dd>Pridaná možnosť "uložiť pri zmene veľkosti". Keď je aktívna, šírka panela sa uloží pri jeho
+                zatvorení</dd>
+
+            <dt data-version="3.6.4">23/2/2020 (v 3.6.4)</dt>
+            <dd>Aktualizovaný štýl posuvníkov pre Firefox</dd>
+            <dd>Aktualizovaná ikona na paneli nástrojov</dd>
+
+            <dt data-version="3.6.3">9/1/2020 (v 3.6.3)</dt>
+            <dd>Opravená chyba, ktorá bránila otvoreniu panela</dd>
+
+            <dt data-version="3.6.2">11/10/2019 (v 3.6.2)</dt>
+            <dd>Vylepšený farebný kontrast prvkov posuvníkov vo svetlom motíve</dd>
+
+            <dt data-version="3.6.1">26/9/2019 (v 3.6.1)</dt>
+            <dd>Vylepšené štýly, aby bol panel odolnejší voči štýlom, ktoré môže mať stránka (ďakujeme
+                Anike Henke za jej spätnú väzbu)
+            </dd>
+
+            <dt data-version="3.6.0">17/9/2019 (v 3.6.0)</dt>
+            <dd>Pridaná možnosť zakázať zvýraznenie prvku na stránke pri kliknutí na položky
+                stromu
+            </dd>
+
+            <dt data-version="3.5.16">3/7/2019 (v 3.5.16)</dt>
+            <dd>Opravená chyba súvisiaca s upozornením na chybu na karte HTML5 outline</dd>
+            <dd>Vylepšené štýly</dd>
+
+            <dt data-version="3.5.15">30/6/2019 (v 3.5.15)</dt>
+            <dd>Opravená chyba súvisiaca s atribútom <em>href</em>, keď nadpisy alebo sekcie majú <em>name</em>
+                alebo <em>id</em></dd>
+
+            <dt data-version="3.5.14">20/6/2019 (v 3.5.14)</dt>
+            <dd>Zobrazenie hodnôt atribútov <em>aria-label</em> a <em>aria-labelledby</em> pre sekcie a
+                vylepšený spôsob zobrazovania ich informácií
+            </dd>
+            <dd>Aktualizované poradie polí v paneli nastavení</dd>
+            <dd>Menší refaktoring na zlepšenie výkonu a zjednodušenie kódu</dd>
+
+            <dt data-version="3.5.13">24/5/2019 (v 3.5.13)</dt>
+            <dd>Opravená chyba pri aktivácii možnosti zobrazovania skrytých nadpisov</dd>
+            <dd>Opravená chyba v štýloch, kvôli ktorej posuvníky nefungovali podľa očakávania</dd>
+            <dd>Vylepšenia výkonu</dd>
+
+            <dt data-version="3.5.12">5/5/2019 (v 3.5.12)</dt>
+            <dd>Umožnené vyššie úrovne ako 6 pri použití atribútu <em>aria-level</em></dd>
+            <dd>Zohľadnenie atribútu <em>role</em> s hodnotou <em>heading</em> v algoritme osnovy</dd>
+            <dd>Zohľadnenie atribútu <em>aria-labelledby</em></dd>
+            <dd>Opravená chyba pri ukladaní nastavení</dd>
+
+            <dt data-version="3.5.11">31/3/2019 (v 3.5.11)</dt>
+            <dd>Vylepšený prvok na zmenu veľkosti panela</dd>
+            <dd>Vylepšený spôsob vytvárania kariet</dd>
+            <dd>Opravené štýlovanie pri zatvorenom paneli</dd>
+
+            <dt data-version="3.5.7">27/3/2019 (v 3.5.7)</dt>
+            <dd>Opravená chyba, ktorá bránila zobrazeniu nadpisov, keď mal niektorý z ich predkov
+                prezentačnú (presentational) rolu</dd>
+
+            <dt data-version="3.5.6">16/2/2019 (v 3.5.6)</dt>
+            <dd>Opravená chyba súvisiaca s textom zobrazovaným pri zohľadnení všetkých nadpisov (vrátane
+                skrytých)</dd>
+
+            <dt data-version="3.5.5">22/1/2019 (v 3.5.5)</dt>
+            <dd>Predvolený tmavý motív</dd>
+            <dd>Pridané nové informácie o stave testu HTML 5 Outline a jeho algoritmu na základe
+                <a href="https://www.w3.org/TR/html53/" target="_blank">pracovného návrhu HTML 5.3 s
+                    vylúčeniami pre ďalšie navrhované odporúčanie</a></dd>
+            <dd>Pri prvej inštalácii karta HTML Outline nie je aktívna (aktivovať ju možno v zobrazení
+                nastavení)
+            </dd>
+
+            <dt data-version="3.5.4">13/1/2019 (v 3.5.4)</dt>
+            <dd>Skryté prvky pre asistenčné technológie sa už predvolene nezohľadňujú (voliteľne ich možno
+                zohľadniť)</dd>
+            <dd>Zohľadnenie atribútu <em>role</em> s hodnotou <em>heading</em>, keď sa používa na určenie
+                nadpisov v dokumente (v kombinácii s atribútom <em>aria-level</em>). Ďakujeme Arnaudovi
+                Delafosseovi za jeho návrh tohto vylepšenia (a predchádzajúceho) a za spätnú väzbu
+            </dd>
+            <dd>Zohľadnenie chyby, keď nadpis neobsahuje žiadny obsah</dd>
+            <dd>Vylepšenia v selektore dokumentov</dd>
+            <dd>Zjednodušené nastavenia</dd>
+            <dd>Opravy chýb (nesprávne identifikované chyby, ...)</dd>
+
+            <dt data-version="3.5.2">24/12/2018 (v 3.5.2)</dt>
+            <dd>Vylepšenia v selektore dokumentov</dd>
+            <dd>Horný okraj pri posúvaní na prvok</dd>
+            <dd>Zabránenie obnoveniu, keď sa dokument aktualizuje, no jeho štruktúra zostáva rovnaká</dd>
+            <dd>Vylepšenia v kvalite kódu (modularizácia, aktualizácie...)</dd>
+            <dd>Oprava chýb, ..</dd>
+
+            <dt data-version="3.5.1">25/11/2018 (v 3.5.1)</dt>
+            <dd>Selektor na získanie štruktúry nadpisov z dokumentov zahrnutých v iframe-och</dd>
+            <dd>Kód rozdelený na moduly</dd>
+            <dd>Vylepšenia výkonu</dd>
+            <dd>Opravy chýb, ..</dd>
+
+            <dt data-version="3.4.3">03/11/2018 (v 3.4.3)</dt>
+            <dd>Nová zbaliteľná ponuka</dd>
+            <dd>Pridané poznámky k vydaniu</dd>
+            <dd>Pridaný obsah pomoci</dd>
+            <dd>Zmeny kódu na zlepšenie efektivity vykonávania</dd>
+
+            <dt>25/10/2018 (v 3.4.2)</dt>
+            <dd>Používateľ môže meniť veľkosť panela</dd>
+            <dd>Panel je možné umiestniť na pravú stranu (ako možnosť)</dd>
+            <dd>Do CSS pridaná vlastnosť <em>overscroll-behavior</em></dd>
+            <dd>Vylepšenia výkonu</dd>
+
+            <dt>23/10/2018 (v 3.4.1)</dt>
+            <dd>Spúšťa sa iba test aktívnej karty</dd>
+            <dd>Pridaný gif pre lepší používateľský zážitok počas načítavania</dd>
+            <dd>Kliknutím na koreň stromu sa stránka posunie na začiatok</dd>
+            <dd>Do widgetu pridaný panel možností</dd>
+            <dd>Oprava chyby v HTML5 Outline, ktorá nezobrazovala všetky sekcie</dd>
+
+            <dt>18/10/2018 (v 3.4.0)</dt>
+            <dd>Zobrazenie obsahu <em>aria-label</em> ako voliteľnej funkcie</dd>
+            <dd>Odkazy v stromoch obsahujú kotvy, takže fungujú ako odkazy na referencie</dd>
+            <dd>Štýlovanie posuvníkov pre Chrome a Vivaldi</dd>
+            <dd>Vylepšená kvalita kódu</dd>
+            <dd>Opravená chyba pri zohľadňovaní nadpisov/sekcií nachádzajúcich sa mimo zobrazenej oblasti ako
+                skrytých</dd>
+
+            <dt>11/10/2018 (v 3.3.7)</dt>
+            <dd>Skryté nadpisy a sekcie sú teraz voliteľne zohľadňované</dd>
+            <dd>Aktualizovaný spôsob zvýrazňovania nadpisu/sekcie</dd>
+            <dd>Vylepšenia výkonu analýzy</dd>
+
+            <dt>09/10/2018 (v 3.3.6)</dt>
+            <dd>Pridaný tmavý motív ako možnosť</dd>
+            <dd>Test HTML5 Outline nastavený ako voliteľný</dd>
+            <dd>Vylepšené celkové štýlovanie</dd>
+            <dd>Opravy chýb</dd>
+        </dl>
+        <p class="note">Poznámky k vydaniu som začal pridávať od tohto bodu, preto pre staršie verzie nie sú
+            k dispozícii žiadne informácie.</p>
+    </div>
+</div>
+</body>
+</html>

--- a/html/releaseNotes/sk.html
+++ b/html/releaseNotes/sk.html
@@ -5,8 +5,51 @@
     <h1 id="release-notes-header" class="headingsmap-exclude">Poznámky k vydaniu</h1>
     <div class="contents custom-scrollbar">
         <dl>
-            <dt data-version="4.9.9">8/8/2026 (v 4.9.9)</dt>
+            <dt data-version="4.10.8">8/8/2026 (v 4.10.8)</dt>
             <dd>Pridaný preklad do slovenčiny od Radoslava Ďuraču (GitHub: <a href="https://github.com/rraddatch" target="_blank">rraddatch</a>). Ďakujem veľmi pekne za túto dobrovoľnú spoluprácu, naozaj si to vážim.</dd>
+
+            <dt data-version="4.10.7">8/4/2026 (v4.10.7)</dt>
+            <dd>Ošetrené neplatné CSS selektory (napr. s menným priestorom) pri vyhodnocovaní štýlov, aby sa predišlo
+                chybám za behu.</dd>
+
+            <dt data-version="4.10.6">19/1/2026 (v4.10.6)</dt>
+            <dd>Pri kliknutí na strom a posúvaní stránky zostáva hore malý okraj, ak sa na stránke nachádza pevne
+                umiestnený (fixed) obsah.</dd>
+            <dd>Pridané ďalšie spôsoby vizuálnej identifikácie nadpisov, keď dokument obsahuje Shadow DOM.
+            </dd>
+
+            <dt data-version="4.10.5">16/1/2026 (v4.10.5)</dt>
+            <dd>Opravená chyba, kvôli ktorej rozšírenie ignorovalo vnorený (nested) obsah Shadow DOM.
+            </dd>
+
+            <dt data-version="4.10.4">15/1/2026 (v4.10.4)</dt>
+            <dd>Opravená regresná chyba, ktorá bránila rozšíreniu kontrolovať obsah vo vnútri Shadow DOM.
+            </dd>
+
+            <dt data-version="4.10.3">26/12/2025 (v4.10.3)</dt>
+            <dd>Vylepšený výkon pri reagovaní na zmeny v DOM-e, ako je vkladanie prvkov, ich odstraňovanie alebo
+                rozbaľovanie panela, s najvýraznejším zlepšením v scenároch, ktoré spúšťajú veľa mutation observerov.
+            </dd>
+
+            <dt data-version="4.10.2">23/7/2025 (v4.10.2)</dt>
+            <dd>Opravené správanie, keď má nadpis atribút inert alebo je potomkom prvku, ktorý ho má.
+                Takéto prvky by sa nemali zobrazovať v zozname, keďže sú neaktívne pre používateľskú interakciu
+                a skryté pre asistenčné technológie. Ešte raz ďakujem Erikovi Kroesovi, že si to všimol a dal mi
+                vedieť.
+            </dd>
+
+            <dt data-version="4.10.1">23/5/2025 (v4.10.1)</dt>
+            <dd>Pridaná klávesová skratka (shift + c) na kopírovanie výsledkov zo stromu. Erik Kroes, ďakujem za
+                tento návrh.
+            </dd>
+            <dd>Opravená chyba v skratke na zobrazenie nadpisov na stránke.</dd>
+
+            <dt data-version="4.9.10">25/4/2025 (v4.9.10)</dt>
+            <dd>Pridaný poľský preklad od Adama (D53 Visual Design). Veľmi pekne ďakujem, Adam.</dd>
+            <dd>Opravená chyba súvisiaca s indexom zoznamu.</dd>
+
+            <dt data-version="4.9.9">22/4/2025 (v4.9.9)</dt>
+            <dd>Opravená chyba, ktorá bránila správnemu fungovaniu nastavenia pre HTML5 Outline.</dd>
 
             <dt data-version="4.9.8">18/4/2025 (v4.9.8)</dt>
             <dd>Opravená chyba, ktorá bránila zobrazeniu výsledkov po zatvorení a opätovnom otvorení panela.</dd>


### PR DESCRIPTION
## Summary

Adds a full Slovak (`sk`) translation:

- `_locales/sk/messages.json` — all 83 UI strings
- `html/configuration/sk.html`
- `html/contribute/sk.html`
- `html/help/sk.html`
- `html/privacyPolicy/sk.html`
- `html/releaseNotes/sk.html` — full changelog history translated (not just the latest entries), including a new entry crediting the translation

Translated to Slovak by Radoslav Ďurač (GitHub: [@rraddatch](https://github.com/rraddatch)). Thank you very much for the opportunity to contribute this translation.

## Verification

- Validated `_locales/sk/messages.json` as valid JSON with all keys present (83/83, matching the English source 1:1).
- Compared HTML tag structure (counts of every tag) between each `sk.html` file and the corresponding current `en.html` — structurally identical in all 5 pages.
- Tested locally against the actually-installed extension (v4.10.7) by loading an unpacked copy with `sk` added to the language list, confirming the translated strings render correctly in the settings dialog, menu, and all sub-pages.

## Note

While testing, I found an unrelated pre-existing bug in the extension itself (not in this translations repo) affecting the dialog title text on repeated opens, for all languages. I've filed that separately as an issue rather than including it here, since it's outside the scope of this translations-only repository.